### PR TITLE
Limit assumed role session name to 64 characters

### DIFF
--- a/scripts/commands/assume/role.bash
+++ b/scripts/commands/assume/role.bash
@@ -40,5 +40,5 @@ then
   TOKEN_CODE="--token-code $TOKEN"
 fi
 
-
-awscli sts assume-role --role-arn arn:aws:iam::${ACCOUNT_ID:-}:role/${ROLE_NAME:-} ${SERIAL_NUMBER:-} ${TOKEN_CODE:-} ${MAX_DURATION:-} --role-session-name $ACCOUNT_ID-$ROLE_NAME-$USERNAME-$RANDOM --output json | jq -r '.Credentials | "export AWS_ACCESS_KEY_ID=" + .AccessKeyId + " AWS_SECRET_ACCESS_KEY=" + .SecretAccessKey + " AWS_SESSION_TOKEN=\"" + .SessionToken + "\" AWS_TOKEN_EXPIRATION=" + .Expiration'
+ROLE_SESSION_NAME=$(echo $ACCOUNT_ID-$ROLE_NAME-$USERNAME-$RANDOM | cut -c -64)
+awscli sts assume-role --role-arn arn:aws:iam::${ACCOUNT_ID:-}:role/${ROLE_NAME:-} ${SERIAL_NUMBER:-} ${TOKEN_CODE:-} ${MAX_DURATION:-} --role-session-name $ROLE_SESSION_NAME --output json | jq -r '.Credentials | "export AWS_ACCESS_KEY_ID=" + .AccessKeyId + " AWS_SECRET_ACCESS_KEY=" + .SecretAccessKey + " AWS_SESSION_TOKEN=\"" + .SessionToken + "\" AWS_TOKEN_EXPIRATION=" + .Expiration'

--- a/scripts/commands/assume/role.bash
+++ b/scripts/commands/assume/role.bash
@@ -40,5 +40,5 @@ then
   TOKEN_CODE="--token-code $TOKEN"
 fi
 
-ROLE_SESSION_NAME=$(echo $ACCOUNT_ID-$ROLE_NAME-$USERNAME-$RANDOM | cut -c -64)
+ROLE_SESSION_NAME=$(echo $RANDOM-$ACCOUNT_ID-$ROLE_NAME-$USERNAME | cut -c -64)
 awscli sts assume-role --role-arn arn:aws:iam::${ACCOUNT_ID:-}:role/${ROLE_NAME:-} ${SERIAL_NUMBER:-} ${TOKEN_CODE:-} ${MAX_DURATION:-} --role-session-name $ROLE_SESSION_NAME --output json | jq -r '.Credentials | "export AWS_ACCESS_KEY_ID=" + .AccessKeyId + " AWS_SECRET_ACCESS_KEY=" + .SecretAccessKey + " AWS_SESSION_TOKEN=\"" + .SessionToken + "\" AWS_TOKEN_EXPIRATION=" + .Expiration'


### PR DESCRIPTION
AWS limits the length of session names, when assuming roles to 64 characters.

With Account IDs being 12 digits long, role names having a 40 character limit, there's only 12 characters left for the username a random number and 3 separators.